### PR TITLE
add bitrate and resolution

### DIFF
--- a/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/BitrateMonitor.java
+++ b/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/BitrateMonitor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 Jim Carroll
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.kognition.pilecv4j.ffmpeg;
+
+/**
+ * Measures the actual bitrate of a media stream by accumulating packet sizes
+ * over a configurable time window. This is essential for streams where the
+ * container metadata does not report a bitrate (e.g., VBR H.264 over RTSP).
+ *
+ * <p>Usage as a {@link PacketFilter} (passes all packets through, just measures):
+ * <pre>{@code
+ * BitrateMonitor monitor = new BitrateMonitor(5000); // 5-second window
+ * mediaContext
+ *     .chain("default")
+ *     .filterPackets(monitor.asPacketFilter())
+ *     .processVideoFrames(consumer);
+ *
+ * // Later, query the measured bitrate:
+ * long bitsPerSec = monitor.getBitsPerSecond();
+ * }</pre>
+ *
+ * <p>Or call {@link #addPacket(int)} directly from any packet-processing callback.
+ */
+public class BitrateMonitor {
+
+    private final long windowMillis;
+
+    private long windowStartTime = -1;
+    private long totalBytes = 0;
+    private long lastBitsPerSecond = 0;
+
+    /**
+     * @param windowMillis the measurement window in milliseconds. Bitrate is
+     *     calculated and reset every time this window elapses. Typical values:
+     *     5000–10000 ms.
+     */
+    public BitrateMonitor(final long windowMillis) {
+        if (windowMillis <= 0)
+            throw new IllegalArgumentException("windowMillis must be > 0");
+        this.windowMillis = windowMillis;
+    }
+
+    /**
+     * Convenience: 10-second default window.
+     */
+    public BitrateMonitor() {
+        this(10_000);
+    }
+
+    /**
+     * Record a packet of the given size. Call this on every packet you want
+     * to include in the bitrate measurement.
+     *
+     * @param packetBytes size of the packet in bytes
+     */
+    public synchronized void addPacket(final int packetBytes) {
+        final long now = System.currentTimeMillis();
+
+        if (windowStartTime < 0) {
+            windowStartTime = now;
+            totalBytes = 0;
+        }
+
+        totalBytes += packetBytes;
+
+        final long elapsed = now - windowStartTime;
+        if (elapsed >= windowMillis) {
+            lastBitsPerSecond = (totalBytes * 8 * 1000) / elapsed;
+            // reset for next window
+            windowStartTime = now;
+            totalBytes = 0;
+        }
+    }
+
+    /**
+     * @return the measured bitrate in bits/second from the last completed
+     *     measurement window, or 0 if no complete window has elapsed yet.
+     */
+    public synchronized long getBitsPerSecond() {
+        return lastBitsPerSecond;
+    }
+
+    /**
+     * @return the measured bitrate in kilobits/second (kbps).
+     */
+    public synchronized long getKbps() {
+        return lastBitsPerSecond / 1000;
+    }
+
+    /**
+     * @return the measured bitrate in megabits/second (Mbps).
+     */
+    public synchronized double getMbps() {
+        return lastBitsPerSecond / 1_000_000.0;
+    }
+
+    /**
+     * Creates a {@link PacketFilter} that passes all packets through (never filters)
+     * but records their sizes for bitrate measurement. Attach this to a
+     * {@link Ffmpeg.MediaProcessingChain} via {@code filterPackets()}.
+     */
+    public PacketFilter asPacketFilter() {
+        return (mediaType, streamIndex, packetNumBytes, isKeyFrame, pts, dts, tbNum, tbDen) -> {
+            addPacket(packetNumBytes);
+            return true; // never filter — just observe
+        };
+    }
+
+    /**
+     * Creates a {@link PacketFilter} that only measures packets from the specified
+     * stream index. All packets are still passed through.
+     */
+    public PacketFilter asPacketFilterForStream(final int targetStreamIndex) {
+        return (mediaType, streamIndex, packetNumBytes, isKeyFrame, pts, dts, tbNum, tbDen) -> {
+            if (streamIndex == targetStreamIndex)
+                addPacket(packetNumBytes);
+            return true;
+        };
+    }
+
+    /**
+     * Reset all accumulated data.
+     */
+    public synchronized void reset() {
+        windowStartTime = -1;
+        totalBytes = 0;
+        lastBitsPerSecond = 0;
+    }
+}

--- a/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/Ffmpeg.java
+++ b/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/Ffmpeg.java
@@ -773,6 +773,24 @@ public class Ffmpeg {
             public final int codecId;
             public final String codecName;
 
+            /**
+             * Video frame width in pixels, or -1 if not a video stream or unknown.
+             */
+            public final int width;
+
+            /**
+             * Video frame height in pixels, or -1 if not a video stream or unknown.
+             */
+            public final int height;
+
+            /**
+             * Stream bit rate in bits/sec as reported by the container/codec, or -1 if unknown.
+             * Note: for some codecs/containers (e.g. variable bitrate H.264 over RTSP) this may
+             * be 0 even though data is flowing. In those cases, bitrate must be estimated by
+             * measuring bytes received over time.
+             */
+            public final long bitRate;
+
             private StreamDetails(final FfmpegApi.internal_StreamDetails sd) {
                 streamIndex = sd.stream_index;
                 mediaType = sd.mediaType;
@@ -782,13 +800,16 @@ public class Ffmpeg {
                 tb_den = sd.tb_den;
                 codecId = sd.codec_id;
                 codecName = sd.codecName;
+                width = sd.width;
+                height = sd.height;
+                bitRate = sd.bit_rate;
             }
 
             @Override
             public String toString() {
                 return "StreamDetails [streamIndex=" + streamIndex + ", mediaType=" + mediaType + ", fps_num=" + fps_num + ", fps_den=" + fps_den
-                    + ", tb_num="
-                    + tb_num + ", tb_den=" + tb_den + ", codecId=" + codecId + ", codecName=" + codecName + "]";
+                    + ", tb_num=" + tb_num + ", tb_den=" + tb_den + ", codecId=" + codecId + ", codecName=" + codecName
+                    + ", width=" + width + ", height=" + height + ", bitRate=" + bitRate + "]";
             }
         }
 

--- a/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/FpsMonitor.java
+++ b/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/FpsMonitor.java
@@ -1,0 +1,40 @@
+package ai.kognition.pilecv4j.ffmpeg;
+
+public class FpsMonitor {
+
+    public final long periodMillis;
+
+    private long periodStart = -1;
+    private long count = -1;
+    private long periodEnd = -1;
+
+    public FpsMonitor(final long periodMillis) {
+        this.periodMillis = periodMillis;
+    }
+
+    /**
+     * This should be called on every frame in order. Once the period
+     * passes the apply will return a non-null which represents the
+     * FPS over the last period. Most of the time this will return null.
+     */
+    public Double apply(final long timestamp) {
+        if(timestamp >= periodEnd) {
+            if(periodStart > 0) {
+                // do the calculation and return
+                final double ret = ((double)count / (double)(periodEnd - periodStart)) * 1000D;
+                reset(timestamp);
+                return ret;
+            }
+            reset(timestamp);
+            return null;
+        } // otherwise
+        count++;
+        return null;
+    }
+
+    private void reset(final long timestamp) {
+        periodStart = timestamp;
+        count = 1;
+        periodEnd = timestamp + periodMillis;
+    }
+}

--- a/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/internal/FfmpegApi.java
+++ b/lib-ffmpeg/src/main/java/ai/kognition/pilecv4j/ffmpeg/internal/FfmpegApi.java
@@ -161,10 +161,14 @@ public class FfmpegApi {
         public int codec_id;
         public String codecName;
 
+        public int width;
+        public int height;
+        public long bit_rate;
+
         public static class ByReference extends internal_StreamDetails implements Structure.ByReference {}
 
         private static final List<String> fo = gfo(internal_StreamDetails.class, "stream_index", "mediaType", "fps_num", "fps_den", "tb_num", "tb_den",
-            "codec_id", "codecName");
+            "codec_id", "codecName", "width", "height", "bit_rate");
 
         public internal_StreamDetails() {}
 
@@ -180,7 +184,7 @@ public class FfmpegApi {
         @Override
         public String toString() {
             return "internal_StreamDetails [mediaType=" + mediaType + ", fps_num=" + fps_num + ", fps_den=" + fps_den + ", tb_num=" + tb_num + ", tb_den="
-                + tb_den + ", codecName=" + codecName + "]";
+                + tb_den + ", codecName=" + codecName + ", width=" + width + ", height=" + height + ", bit_rate=" + bit_rate + "]";
         }
     }
 

--- a/native-ffmpeg/src/main/cpp/api/StreamDetails.cpp
+++ b/native-ffmpeg/src/main/cpp/api/StreamDetails.cpp
@@ -34,6 +34,10 @@ uint64_t StreamDetails::fillStreamDetails(AVFormatContext* formatCtx, StreamDeta
 
         details.codec_id = pLocalCodecParameters->codec_id;
 
+        details.width = pLocalCodecParameters->width;
+        details.height = pLocalCodecParameters->height;
+        details.bit_rate = pLocalCodecParameters->bit_rate;
+
         const AVCodecDescriptor* cd = avcodec_descriptor_get(pLocalCodecParameters->codec_id);
         if (cd)
           details.setCodecName(cd->name);

--- a/native-ffmpeg/src/main/cpp/api/StreamDetails.h
+++ b/native-ffmpeg/src/main/cpp/api/StreamDetails.h
@@ -29,6 +29,10 @@ struct StreamDetails {
   int32_t codec_id = -1;
   char* codecName = nullptr;
 
+  int32_t width = -1;
+  int32_t height = -1;
+  int64_t bit_rate = -1;
+
   inline ~StreamDetails() {
     if (codecName)
       delete [] codecName;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the native↔JNA `StreamDetails` struct layout and public Java API, which can break compatibility if native and Java versions mismatch or if downstream code relies on previous fields.
> 
> **Overview**
> Adds stream-level metadata to `MediaContext.StreamDetails`, exposing `width`, `height`, and container-reported `bitRate` end-to-end from native FFmpeg (`StreamDetails.h/.cpp`) through JNA (`FfmpegApi.internal_StreamDetails`) to Java (`Ffmpeg.StreamDetails`).
> 
> Introduces two new utility classes: `BitrateMonitor` to estimate actual bitrate by observing packet sizes over a rolling time window (optionally via a pass-through `PacketFilter`), and `FpsMonitor` to compute observed FPS over a configurable period.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfd41580f5e97bc1855b26775ac58734acd565c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->